### PR TITLE
Send raw data on an SML message 

### DIFF
--- a/secs/secs2body.py
+++ b/secs/secs2body.py
@@ -194,16 +194,33 @@ class AbstractSecs2Body:
 
     
 class Secs2AsciiBody(AbstractSecs2Body):
+    _hack = True  # XXX: able to work with a non-visible ASCII character
 
     def __init__(self, item_type, value):
+        if self._hack:
+            super(Secs2AsciiBody, self).__init__(item_type, value)  # Keep it as is
+            return
+
         super(Secs2AsciiBody, self).__init__(item_type, str(value))
 
     def _create_to_sml_value(self):
-        return len(self._value), ('"' + self._value + '"')
+        # ret = len(self._value), ('"' + self._value + '"')
+        s = self._value
+        if self._hack:
+            s = ''.join(['%c' % c for c in s])
+        return len(s), (f'"{s}"')
 
     def _create_to_bytes_value(self):
+        if self._hack:
+            s = self._value
+            if type(s) is str:
+                s = s.encode(encoding='ascii')
+            else:
+                s = bytes([c for c in s])
+            return s
+
         return self._value.encode(encoding='ascii')
-    
+
     @staticmethod
     def build(item_type, value):
         return Secs2AsciiBody(item_type, value)

--- a/secs/secs2body.py
+++ b/secs/secs2body.py
@@ -194,10 +194,11 @@ class AbstractSecs2Body:
 
     
 class Secs2AsciiBody(AbstractSecs2Body):
-    _hack = True  # XXX: able to work with a non-visible ASCII character
 
     def __init__(self, item_type, value):
-        if self._hack:
+        self._extended = os.getenv('SECS_EXTENDED')
+
+        if self._extended:
             super(Secs2AsciiBody, self).__init__(item_type, value)  # Keep it as is
             return
 
@@ -206,12 +207,12 @@ class Secs2AsciiBody(AbstractSecs2Body):
     def _create_to_sml_value(self):
         # ret = len(self._value), ('"' + self._value + '"')
         s = self._value
-        if self._hack:
+        if self._extended:
             s = ''.join(['%c' % c for c in s])
         return len(s), (f'"{s}"')
 
     def _create_to_bytes_value(self):
-        if self._hack:
+        if self._extended:
             s = self._value
             if type(s) is str:
                 s = s.encode(encoding='ascii')
@@ -472,6 +473,11 @@ class Secs2BodyBuilder:
                 return tt[5](tt, vv), end_index
 
             elif tt[0] == 'A':
+                if os.getenv('SECS_EXTENDED'):
+                    v = bs[start_index:end_index]
+                    v = v.decode(encoding='ascii') if all([c <= 128 for c in v]) else bytes([c for c in v])
+                    return tt[5](tt, v), end_index
+
                 v = bs[start_index:end_index].decode(encoding='ascii')
                 return tt[5](tt, v), end_index
 


### PR DESCRIPTION
I got trying to send unformatted data which are not only an ASCII character, but also the possible char between 0..255 -- raw data.
The following is the result from the device that received the message S18F7.

[Equipment] received primary message from:
{
"baudrate": 9600,
"device_id": 0,
"is_equip": true,
"is_master": true,
"name": "equip-master",
"port": "/dev/pts/12",
"protocol": "SECS-I-on-pySerial"
}
[Equipment] primary message:
[00 00|92 07|00 00|00 00 00 01]
S18F7 W
<L [4]
<A [2] "01" >
<A [3] "S01" >
<U4 [1] 8 >
<A [11] "b'UUUUUUUU'" > # <-- Unformatted data

This pull-request will help the raw data can be sent:
A [8] "UUUUUUUU"

*** Please don't forget to put this following code before start the object:

    os.environ['SECS_EXTENDED'] = 'True'
